### PR TITLE
disable donate

### DIFF
--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -37,9 +37,6 @@
           </ul>
       </li>
       <li>
-        <a href="/donate"><span class="glyphicon glyphicon-heart"></span> Donate</a>
-      </li>
-      <li>
         <a href="https://store.dataskeptic.com"><span class="glyphicon glyphicon-shopping-cart"></span> Store</a>
       </li>
     </ul>


### PR DESCRIPTION
Paypal has changed something and now the Donate button no longer works.  We need to remove it from production until such time as resources can be allocated to look into this.  For reference, no one has used this link.  I recommend abandoning this effort as it will likely cost more in labor to fix than donations we will receive.  In the history of the show, we've received 2 donations via buttons like this.  