### PR TITLE
redirect login to portal

### DIFF
--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -42,7 +42,7 @@
     </ul>
     <ul class="nav navbar-nav navbar-right">
       <li class="navbar-right">
-        <a href="/login"><span class="glyphicon glyphicon-menu"></span>Members Login</a>
+        <a href="https://portal.dataskeptic.com/members"><span class="glyphicon glyphicon-menu"></span>Members Login</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
Change the "Members login" link in the upper right CURRENTLY goes to:

![image](https://user-images.githubusercontent.com/1054674/84060790-a7cf4a00-a971-11ea-9f07-a7efe15fbe79.png)


This Pull Requests updates it to redirect to THIS page instead:

![image](https://user-images.githubusercontent.com/1054674/84060741-9423e380-a971-11ea-9262-e10a22e5e7e2.png)
